### PR TITLE
Fix raw tx encode

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -40,6 +40,6 @@ pub async fn prepare_rpc_request(method: &str, params: Value) -> Value {
 
 pub fn envelope_to_raw_bytes(tx: &TxEnvelope) -> Bytes {
     let mut encoded = Vec::new();
-    tx.network_encode(&mut encoded);
+    tx.encode_2718(&mut encoded);
     encoded.into()
 }


### PR DESCRIPTION
It seems that encode_2718 is the right method to encode raw tx.

reth uses decode_2718 when recover from raw tx, https://github.com/paradigmxyz/reth/blob/v1.1.1/crates/rpc/rpc-eth-types/src/utils.rs#L18

I have written a simple code to verify it. https://github.com/Akagi201/evm-tools/blob/master/gen-raw-tx/src/main.rs#L93
When I use network_encode, the rpc server return an error: `error code -32602: failed to decode signed transaction`
When I use encode_2718, there is no error, and the sendRawTransaction succeed. https://holesky.etherscan.io/tx/0x6e831b775e542f84fd5a59a9c8311713dc690fc14832e41ab216ff237d59cbbf